### PR TITLE
Configure PipelineMonitor to publish as a .NET tool

### DIFF
--- a/src/PipelineMonitor/PipelineMonitor.csproj
+++ b/src/PipelineMonitor/PipelineMonitor.csproj
@@ -3,8 +3,17 @@
   <!-- NuGet Package authoring best practices:
     https://learn.microsoft.com/en-us/nuget/create-packages/package-authoring-best-practices -->
 
+  <!-- .NET Tool creation guide:
+    https://learn.microsoft.com/en-us/dotnet/core/tools/global-tools-how-to-create -->
+
   <!-- TargetFramework and other common properties are inherited from
     ../Directory.Build.props and shared by all projects. -->
+
+  <PropertyGroup Label="Tool Configuration">
+    <OutputType>Exe</OutputType>
+    <PackAsTool>true</PackAsTool>
+    <ToolCommandName>pipelinemon</ToolCommandName>
+  </PropertyGroup>
 
   <PropertyGroup Label="Package Metadata">
     <PackageId>PipelineMonitor</PackageId>

--- a/src/PipelineMonitor/Program.cs
+++ b/src/PipelineMonitor/Program.cs
@@ -1,0 +1,12 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 Logan Bussell
+// SPDX-License-Identifier: MIT
+
+namespace PipelineMonitor;
+
+public class Program
+{
+    public static void Main(string[] args)
+    {
+        Console.WriteLine("PipelineMonitor");
+    }
+}


### PR DESCRIPTION
This PR converts PipelineMonitor from a class library to a .NET tool that can be installed via `dotnet tool install`.

## Changes
- Added `OutputType`, `PackAsTool`, and `ToolCommandName` properties to the csproj
- Created `Program.cs` with entry point

## Usage
After publishing, the tool can be installed with:
```
dotnet tool install -g PipelineMonitor
```

And run with:
```
pipelinemon
```

Reference: https://learn.microsoft.com/en-us/dotnet/core/tools/global-tools-how-to-create